### PR TITLE
Handle case of IP address with no CIDR range.

### DIFF
--- a/pingscanner.go
+++ b/pingscanner.go
@@ -88,7 +88,7 @@ func (d PingScanner) Scan() (aliveIPs []string, err error) {
 
 func expandCidrIntoIPs(cidr string) ([]string, error) {
 	splitted := strings.Split(cidr, "/")
-	if splitted[1] == "32" {
+	if len(splitted) == 1 || splitted[1] == "32" {
 		return []string{splitted[0]}, nil
 	}
 	ip, ipnet, err := net.ParseCIDR(cidr)


### PR DESCRIPTION
This fixes a panic in vuls, when issuing a command such as:

$ ./vuls discover 192.168.1.1