### PR TITLE
fix: fix ping options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kotakanbe/go-pingscanner
+
+go 1.24

--- a/version.go
+++ b/version.go
@@ -4,4 +4,4 @@ package pingscanner
 const Name string = "go-pingscanner"
 
 // Version ... Version
-const Version string = "0.1.0"
+const Version string = "0.2.0"


### PR DESCRIPTION
## setup
```diff
:100644 100644 f64ad82 0000000 M	example/main.go

diff --git a/example/main.go b/example/main.go
index f64ad82..58e1e74 100644
--- a/example/main.go
+++ b/example/main.go
@@ -8,8 +8,7 @@ import (
 
 func main() {
 	scanner := ps.PingScanner{
-		//  CIDR: "192.168.11.0/24",
-		CIDR: "192.168.11.2/32",
+		CIDR: "127.0.0.0/24",
 		PingOptions: []string{
 			"-c1",
 			"-t1",

```

## before
```console
$ go mod init github.com/kotakanbe/go-pingscanner
$ cd example
$ go run main.go | wc -l
100
```

## after
```console
$ cd example
$ go run main.go | wc -l
254
```